### PR TITLE
Update README.md to link to correct link for MSI and EXE instead of M…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a GitHub Action to update EXE and MSI apps in the Microsoft Store.
 
 2. You must associate your Azure AD directory with your Partner Center account to obtain the credentials to allow this extension to access your account and perform actions on your behalf.
 
-3. The app you want to publish must already exist: this extension can only publish updates to existing applications. You can [create your app in Partner Center](https://msdn.microsoft.com/windows/uwp/publish/create-your-app-by-reserving-a-name).
+3. The app you want to publish must already exist: this extension can only publish updates to existing applications. You can [create your app in Partner Center]([https://msdn.microsoft.com/windows/uwp/publish/create-your-app-by-reserving-a-name](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/msi/reserve-your-apps-name).
 
 4. You must have already [created at least one submission](https://msdn.microsoft.com/windows/uwp/publish/app-submissions) for your app before you can use the Publish task provided by this extension. If you have not created a submission, the task will fail.
 


### PR DESCRIPTION
This GitHub action is for EXE or MSI while the link in readme takes us to MSIX link which is incorrect. 

Proposing the change here.